### PR TITLE
Fixed readme build instructions to fix error 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -316,4 +316,4 @@ saveAsync(obj1).onSuccessTask(new Continuation<ParseObject, ParseObject>() {
 
 # Build Instructions
 
-    ./gradlew clean :Bolts:jar :Bolts:javadocs
+    ./gradlew clean :Bolts:jar :Bolts:javadoc


### PR DESCRIPTION
Was getting this error when running gradle instructions: "Task 'javadocs' not found in project ':Bolts'. Some candidates are: 'javadoc'."

Fixed on my machine at least. OS X 10.8.5
